### PR TITLE
Only display stderr if there is output

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = function (options) {
           proxy.emit('error', err);
           return;
         }
-        console.log('%s', stderr);
+        if (stderr) console.log('%s', stderr);
 
         filename = target || tmp.sync(stdout);
 


### PR DESCRIPTION
If there is no output to `stderr`, it prints a blank line in the build log, which can be annoying sometimes.